### PR TITLE
hotfix(actions): return files should always be an array

### DIFF
--- a/src/actions/UploadAction.php
+++ b/src/actions/UploadAction.php
@@ -156,7 +156,7 @@ class UploadAction extends BaseAction
 
             $result['files'][] = $output;
         }
-        return $this->multiple ? $result : array_shift($result);
+        return $result;
     }
 
     /**


### PR DESCRIPTION
fixed #136 