### PR TITLE
fix double slash issue if no pathPrefix specified

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -129,11 +129,11 @@ class Storage extends Component
                     Yii::$app->security->generateRandomString(),
                     $fileObj->getExtension()
                 ]);
-                $path = implode(DIRECTORY_SEPARATOR, [$pathPrefix, $dirIndex, $filename]);
+                $path = implode(DIRECTORY_SEPARATOR, array_filter([$pathPrefix, $dirIndex, $filename]));
             } while ($this->getFilesystem()->has($path));
         } else {
             $filename = $fileObj->getPathInfo('filename');
-            $path = implode(DIRECTORY_SEPARATOR, [$pathPrefix, $dirIndex, $filename]);
+            $path = implode(DIRECTORY_SEPARATOR, array_filter([$pathPrefix, $dirIndex, $filename]));
         }
 
         $this->beforeSave($fileObj->getPath(), $this->getFilesystem());


### PR DESCRIPTION
Добрый день, пользуемся вашим пакетом для загрузки фото. После обновления версии пакета с ^1.0.0 до версии 2.* у нас в проекте появились проблемы с сохранением фото.

 // — двойной слэш в пути к файлу, если не указывать $pathPrefix, который по умолчанию = ''
прим. https://yii2-starter-kit.herokuapp.com/storage/web/source//1/nMhKzqTyva_-VD3KhAJ24NZp20JVbhE-.jpg"