### PR TITLE
Storage option not to use dirindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To work with the File Kit you need to configure FileStorage first. This componen
 ```php
 'fileStorage'=>[
     'class' => 'trntv\filekit\Storage',
+    'useDirindex' => true,
     'baseUrl' => '@web/uploads'
     'filesystem'=> ...
         // OR

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -66,6 +66,10 @@ class Storage extends Component
      */
     public $defaultSaveConfig = [];
     /**
+     * @var bool
+     */
+    public $useDirindex = true;
+    /**
      * @var int
      */
     private $dirindex = 1;
@@ -214,10 +218,14 @@ class Storage extends Component
     }
 
     /**
-     * @return false|int|string
+     * @param string $path
+     * @return false|int|string|null
      */
     protected function getDirIndex($path = '')
     {
+        if (!$this->useDirindex) {
+            return null;
+        }
         $normalizedPath = '.dirindex';
         if (isset($path)) {
             $normalizedPath = $path . DIRECTORY_SEPARATOR . '.dirindex';


### PR DESCRIPTION
If useDirindex = false, then the dirindex parameter will not be included in the file upload path.